### PR TITLE
support search query in redirect URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ export default authMiddleware({
 
 	// The URL to redirect to if the user is not authenticated
 	// Defaults to process.env.SIGN_IN_ROUTE or '/sign-in' if not provided
+	// NOTE: In case it contains query parameters that exist in the original URL, they will override the original query parameters. e.g. if the original URL is /page?param1=1&param2=2 and the redirect URL is /sign-in?param1=3, the final redirect URL will be /sign-in?param1=3&param2=2
 	redirectUrl?: string
 
 	// An array of public routes that do not require authentication

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -3,7 +3,6 @@ declare const BUILD_VERSION: string;
 
 export const DESCOPE_SESSION_HEADER = 'x-descope-session';
 
-// eslint-disable-next-line import/prefer-default-export
 export const baseHeaders = {
 	'x-descope-sdk-name': 'nextjs',
 	'x-descope-sdk-version': BUILD_VERSION

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,0 +1,21 @@
+/* eslint-disable import/prefer-default-export */
+
+/*
+Merges multiple search params into one.
+It will override according to the order of the search params
+Examples:
+ - mergeSearchParams('?a=1', '?b=2') => 'a=1&b=2'
+ - mergeSearchParams('?a=1', '?a=2') => 'a=2'
+ - mergeSearchParams('?a=1', '?a=2', '?b=3') => 'a=2&b=3'
+*/
+export const mergeSearchParams = (...searchParams: string[]): string => {
+	const res = searchParams.reduce((acc, curr) => {
+		const currParams = new URLSearchParams(curr);
+		currParams.forEach((value, key) => {
+			acc.set(key, value);
+		});
+		return acc;
+	}, new URLSearchParams());
+
+	return res.toString();
+};

--- a/test/server/authMiddleware.test.ts
+++ b/test/server/authMiddleware.test.ts
@@ -116,4 +116,17 @@ describe('authMiddleware', () => {
 			pathname: customRedirectUrl
 		});
 	});
+
+	it('support and redirect url with search params', async () => {
+		mockValidateJwt.mockRejectedValue(new Error('Invalid JWT'));
+		const customRedirectUrl = '/custom-sign-in?redirect=/another-path';
+		const middleware = authMiddleware({ redirectUrl: customRedirectUrl });
+		const mockReq = createMockNextRequest({ pathname: '/private' });
+
+		await middleware(mockReq);
+		expect(NextResponse.redirect).toHaveBeenCalledWith({
+			pathname: '/custom-sign-in',
+			search: `redirect=${encodeURIComponent('/another-path')}`
+		});
+	});
 });

--- a/test/server/utils.test.ts
+++ b/test/server/utils.test.ts
@@ -1,0 +1,15 @@
+import { mergeSearchParams } from '../../src/server/utils';
+
+describe('utils', () => {
+	describe('mergeSearchParams', () => {
+		it('should merge search params', () => {
+			const searchParams = mergeSearchParams('a=1&b=2', 'c=3&d=4');
+			expect(searchParams).toBe('a=1&b=2&c=3&d=4');
+		});
+
+		it('should merge search params with duplicate keys', () => {
+			const searchParams = mergeSearchParams('a=1&b=2', 'a=3&d=4');
+			expect(searchParams).toBe('a=3&b=2&d=4');
+		});
+	});
+});


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/5884

## Description

support search query in redirect URL


NOTE: In case it contains query parameters that exist in the original URL, they will override the original query parameters. e.g. if the original URL is /page?param1=1&param2=2 and the redirect URL is /sign-in?param1=3, the final redirect URL will be /sign-in?param1=3&param2=2

