### PR TITLE
Added Private Route Array

### DIFF
--- a/src/server/authMiddleware.ts
+++ b/src/server/authMiddleware.ts
@@ -25,6 +25,10 @@ type MiddlewareOptions = {
 	// - process.env.SIGN_IN_ROUTE or /sign-in if not provided
 	// - process.env.SIGN_UP_ROUTE or /sign-up if not provided
 	publicRoutes?: string[];
+
+	// An array of private routes that require authentication
+	// If privateRoutes is defined, routes not listed in this array will default to public routes
+	privateRoutes?: string[];
 };
 
 const getSessionJwt = (req: NextRequest): string | undefined => {
@@ -45,8 +49,9 @@ const isPublicRoute = (req: NextRequest, options: MiddlewareOptions) => {
 		req.nextUrl.pathname
 	);
 	const isPublic = options.publicRoutes?.includes(req.nextUrl.pathname);
+	const isPrivate = options.privateRoutes?.includes(req.nextUrl.pathname);
 
-	return isDefaultPublicRoute || isPublic;
+	return isDefaultPublicRoute || isPublic || !isPrivate;
 };
 
 const addSessionToHeadersIfExists = (


### PR DESCRIPTION
## Related Issues

Fixes <link_to_github_issue>

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

For apps that are simple and require most routes to be public and have a few strictly defined `private` routes, this change will make every route public by default, if `privateRoutes` is defined. The routes defined in the array will therefore be protected instead. 

Essentially the opposite of the `publicRoutes` array in the `middleware.ts`.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
